### PR TITLE
Add unit declarator to module, class and role declarations

### DIFF
--- a/lib/Dispatcher/Rule.pm
+++ b/lib/Dispatcher/Rule.pm
@@ -1,4 +1,4 @@
-class Dispatcher::Rule;
+unit class Dispatcher::Rule;
 has @.pattern;
 has @.args;
 

--- a/lib/November/Cache.pm
+++ b/lib/November/Cache.pm
@@ -1,4 +1,4 @@
-role November::Cache;
+unit role November::Cache;
 
 use November::Config;
 

--- a/lib/November/Session.pm
+++ b/lib/November/Session.pm
@@ -1,4 +1,4 @@
-role November::Session;
+unit role November::Session;
 
 method sessionfile-path {
     return $.config.server_root  ~ 'data/sessions';

--- a/lib/November/Storage.pm
+++ b/lib/November/Storage.pm
@@ -1,4 +1,4 @@
-class November::Storage;
+unit class November::Storage;
 
 method wiki_page_exists($page)                               { ... }
 

--- a/lib/November/URI.pm
+++ b/lib/November/URI.pm
@@ -1,4 +1,4 @@
-class November::URI;
+unit class November::URI;
 
 # This class used to be called just 'URI', but there was a collision with
 # the eponymous class in the 'uri' project. Arguably, that class has more

--- a/lib/November/Utils.pm
+++ b/lib/November/Utils.pm
@@ -1,4 +1,4 @@
-module November::Utils;
+unit module November::Utils;
 
 sub r_remove( $str is rw ) is export {
     $str .= subst( /\\r/, '', :g );

--- a/lib/Text/Markup/Wiki/Minimal.pm
+++ b/lib/Text/Markup/Wiki/Minimal.pm
@@ -1,4 +1,4 @@
-class Text::Markup::Wiki::Minimal;
+unit class Text::Markup::Wiki::Minimal;
 
 method format($text, :$link_maker, :$extlink_maker) {
     my @pars = grep { $_ ne "" },


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.